### PR TITLE
Force symmetry

### DIFF
--- a/solver/solve_AxB.m
+++ b/solver/solve_AxB.m
@@ -78,7 +78,7 @@ else
             disp('Using distributed Ax=b');
             x2 = gather(distributed(K)\distributed(Lm));
         else
-            %verbose sparse solver
+            %make sparse solver verbose
             spparms('spumoni',2);
             %force symmetry
             K = 0.5*(K+K');

--- a/solver/solve_AxB.m
+++ b/solver/solve_AxB.m
@@ -78,6 +78,11 @@ else
             disp('Using distributed Ax=b');
             x2 = gather(distributed(K)\distributed(Lm));
         else
+            %verbose sparse solver
+            spparms('spumoni',2);
+            %force symmetry
+            K = 0.5*(K+K');
+            %original solve
             x2 = K\Lm;
         end
         


### PR DESCRIPTION
machine precision level asymmetry forces MATLAB's sparse solver to treat the K matrix as asymmetric. This was causing up to 5x larger RAM usage. 
K should be symmetric. The way we construct it (A' x W x A) should create a symmetric matrix.
This fix makes K symmetric, as evidenced by a check with issymmetric() and also by looking at the now-verbose sparse solver output, which I am leaving on by default now.